### PR TITLE
feat: add user domain and email to debug logs with invite and reset t…

### DIFF
--- a/app/src/auth/routes.py
+++ b/app/src/auth/routes.py
@@ -69,7 +69,7 @@ async def invite_user(
                                   template_name=email_service.EmailTemplate.INVITATION,
                                   token=token,
                                   language=body.language)
-        logger.debug(f"Invitation token: {token}")
+        logger.debug(f"Invitation token ({domain}\\{body.email}): {token}")
         return {"message": RETURN_MSG.email_sent % "Invitation"}
     except PydanticCustomError as e:
         logger.error(f"{e}")
@@ -238,7 +238,7 @@ async def forgot_pasword(
                                   template_name=email_service.EmailTemplate.RESET_PASS,
                                   token=token,
                                   language=language)
-        logger.debug(f"Reset token: {token}")
+        logger.debug(f"Reset token ({domain}\\{email}): {token}")
         return {"message": RETURN_MSG.email_sent % "Reset password"}
     except HTTPException as e:
         logger.error(f"{e}")


### PR DESCRIPTION
Add user domain and email to debug logs with invite and reset tokens:
<img width="2516" height="297" alt="image" src="https://github.com/user-attachments/assets/77b8b83d-49af-4e4b-b685-c140b0321234" />
